### PR TITLE
#20 Adicionando centralização na "Descrição sobre a cidade" 

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -254,7 +254,8 @@ body{
 
 .intro-cidade p{
     margin:2rem;
-    font-size: 1rem;
+    font-size: 1.5rem;
+    line-height: 2rem;
 }
 
 .intro--orientacoes img {
@@ -288,6 +289,7 @@ body{
 
 .intro--descricao{
   margin-top: .75rem;
+  max-width: 1280px;
 }
 
 .left {


### PR DESCRIPTION
Adicionei max-width: 1280px; para centralizar a caixa que estava esticada. Também percebi que o tamanho da letra estava dificultando a leitura e adicionei um font-size  na classe **.intro-cidade p** para aumentar um pouco o tamanho da letra, dei também um pequeno espaçamento entre linhas para facilitar a leitura.


Antes:

![_C__Users_Angela_Projetos_pyne2023_index html (2)](https://github.com/pythonNordeste/pyne2023/assets/89156781/31e0c65d-6cd6-4ac6-8381-f547a54162f5)

Depois:

![_C__Users_Angela_Projetos_pyne2023_index html (1)](https://github.com/pythonNordeste/pyne2023/assets/89156781/247cab1a-5a94-4ad5-8381-524fc51b416c)

