### PR TITLE
Adicionar link do Pretalx no site #26

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,9 @@
     <div class="c4p">
         <a href="https://pretalx.com/python-nordeste-2023/cfp" target="_blank" class="btn-c4p">Submissão de atividades</a>
     </div>
+    <div class="c4p">
+        <a href="https://pretalx.com/python-nordeste-2023/schedule/" target="_blank" class="btn-c4p">Cronograma do evento</a>
+    </div>
     <section class="intro" id="intro">
         <div class="intro--descricao">
             <h2>Conheça mais sobre a cidade-sede da PyNE 2023!</h2>


### PR DESCRIPTION
Adicionei o botão "Cronograma do evento" no `header` com [ Esse link ]( https://pretalx.com/python-nordeste-2023/schedule/)
Ele ainda não foi estilizado. Vou fazer isso na segunda-feira

Ficou dessa forma: 

![_C__Users_Angela_Projetos_pyne2023_index html (7)](https://github.com/pythonNordeste/pyne2023/assets/89156781/b595d8ac-793b-46df-8b4d-e6e309dbde5d)
