### PR TITLE
Atualizando footer da página cdc

### DIFF
--- a/cdc.html
+++ b/cdc.html
@@ -222,7 +222,8 @@
                         <img class="social-media--icons" src="./img/icons/EMAIL.svg" alt="Email" />
                         <!-- nordeste@python.org.br -->
                     </a>
-                    <a href="https://www.instagram.com/pythonnordeste/" target="_blank" rel="noopener noreferrer">
+                    <a href="https://www.instagram.com/pythonnordeste/" target="_blank"
+                        rel="noopener noreferrer">
                         <img class="social-media--icons" src="./img/icons/INSTAGRAM.svg" alt="Instagram" />
                     </a>
                     <a href="https://twitter.com/pythonnordeste" target="_blank" rel="noopener noreferrer">
@@ -240,8 +241,8 @@
                     </a>
                     <hr>
                     <small class="footer__note">
-                        22 a 24 de setembro de 2023 | Salvador - BA, Brasil | Feito com <3 por pythonistas nordestinos
-                            </small>
+                        22 a 24 de setembro de 2023 | Salvador - BA, Brasil | Feito com <3 por pythonistas
+                            nordestinos </small>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adicionei script do `footer` da página index na página cdc, fiz o teste localmente e está responsivo. 

Está dessa forma Mobile:

![footer-cdc](https://github.com/pythonNordeste/pyne2023/assets/89156781/03150a3c-309c-4f24-9bc5-6c1f94739aab)

Está dessa forma Desktop: 

![footer-desktop](https://github.com/pythonNordeste/pyne2023/assets/89156781/749b9b15-2868-48d3-a019-b6dfbcd03417)